### PR TITLE
Handle router logit requests conditionally in inference

### DIFF
--- a/configs/run_train_mixtral_router.yaml
+++ b/configs/run_train_mixtral_router.yaml
@@ -1,0 +1,49 @@
+hydra:
+  run:
+    dir: ${output_dir}/${now:%Y-%m-%d}/${now:%H-%M-%S}
+
+model:
+  pretrained_model_name_or_path: mistralai/Mixtral-8x7B-Instruct-v0.1
+  device_map: auto
+  trust_remote_code: true
+  torch_dtype: torch.bfloat16
+
+ue_layer:
+  path: ''
+  pos_weight: 3
+  output_attention: false
+  head_cfg:
+    head_type: claim
+    feature_extractor:
+    - name: luh.feature_extractors.mixtral_router
+      layer_nums: all
+      normalize: true
+    uncertainty_head:
+      head_dim: 256
+      n_layers: 2
+      n_heads: 4
+      dropout: 0.1
+
+dataset:
+  path: hf:llm-uncertainty-head/train_akimbio_mistral
+  num_instances: 0
+  test_size: 0.0
+  validation: test
+
+training_arguments:
+  num_train_epochs: 3
+  learning_rate: 0.0001
+  warmup_ratio: 0.05
+  weight_decay: 0.1
+  gradient_accumulation_steps: 1
+  per_device_train_batch_size: 8
+  max_grad_norm: 1.0
+
+do_train: true
+do_eval: true
+do_hyperopt: false
+do_save_checkpoints: true
+do_save_final_model: true
+report_to: none
+output_dir: ./workdir/train
+do_predict: false

--- a/luh/calculator_infer_luh.py
+++ b/luh/calculator_infer_luh.py
@@ -39,6 +39,10 @@ class CalculatorInferLuh(StatCalculator):
         self.uncertainty_head = uncertainty_head.to(device)
         self.uncertainty_head.eval()
         self.output_attentions = self.uncertainty_head.output_attentions
+        # Request router logits only when the underlying feature extractor needs them.
+        self.output_router_logits = getattr(
+            self.uncertainty_head, "output_router_logits", lambda: False
+        )()
         self.predict_token_uncertainties = predict_token_uncertainties
 
     @staticmethod
@@ -87,6 +91,7 @@ class CalculatorInferLuh(StatCalculator):
             out = model(
                 **combined_batch,
                 output_attentions=self.output_attentions,
+                output_router_logits=self.output_router_logits,
                 output_hidden_states=True,
             )
             logits = out.logits.log_softmax(-1) # Why log_softmax?
@@ -261,6 +266,7 @@ class CalculatorInferLuh(StatCalculator):
             "max_new_tokens": max_new_tokens,
             "min_new_tokens": 2,
             "output_attentions": self.output_attentions,
+            "output_router_logits": self.output_router_logits,
             "output_hidden_states": True,
             "num_return_sequences": 1,
             "do_sample": False,

--- a/luh/cli/train/causal_lm_with_uncertainty_layer.py
+++ b/luh/cli/train/causal_lm_with_uncertainty_layer.py
@@ -21,7 +21,8 @@ class CausalLMWithUncertaintyLayer(PreTrainedModel):
         base_model,
         ue_head,
         ue_pos_weight: float,
-        output_attention: bool = False
+        output_attention: bool = False,
+        output_router_logits: bool = False,
     ):
         super().__init__(PretrainedConfig())
 
@@ -29,6 +30,7 @@ class CausalLMWithUncertaintyLayer(PreTrainedModel):
         self.ue_head = ue_head
         self._ue_pos_weight = ue_pos_weight
         self._output_attention = output_attention
+        self._output_router_logits = output_router_logits
 
     def generate(self, *args, **kwargs):
         kwargs.update(
@@ -36,7 +38,8 @@ class CausalLMWithUncertaintyLayer(PreTrainedModel):
                 "return_dict_in_generate": True,
                 "output_scores": True,
                 "output_hidden_states": True,
-                "output_attentions": self._output_attention
+                "output_attentions": self._output_attention,
+                "output_router_logits": self._output_router_logits,
             }
         )
 
@@ -62,6 +65,7 @@ class CausalLMWithUncertaintyLayer(PreTrainedModel):
         )
         output_hidden_states = True
         output_attentions = self._output_attention
+        output_router_logits = self._output_router_logits
 
         outputs = self.orig_base_model(
             input_ids=input_ids,
@@ -69,8 +73,9 @@ class CausalLMWithUncertaintyLayer(PreTrainedModel):
             labels=labels,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            output_router_logits=output_router_logits,
             return_dict=return_dict,
-            **kwargs
+            **kwargs,
         )
         logits = outputs.logits
         outputs.context_lengths = context_lengths

--- a/luh/cli/train/causal_lm_with_uncertainty_layer_claim.py
+++ b/luh/cli/train/causal_lm_with_uncertainty_layer_claim.py
@@ -14,13 +14,15 @@ class CausalLMWithUncertaintyLayerClaim(PreTrainedModel):
         base_model,
         ue_head,
         ue_pos_weight: float,
-        output_attention: bool = False
+        output_attention: bool = False,
+        output_router_logits: bool = False,
     ):
         super().__init__(PretrainedConfig())
 
         self.orig_base_model = base_model
         self.ue_head = ue_head
         self._output_attention = output_attention
+        self._output_router_logits = output_router_logits
         self._ue_pos_weight = ue_pos_weight
 
     def generate(self, *args, **kwargs):
@@ -44,6 +46,7 @@ class CausalLMWithUncertaintyLayerClaim(PreTrainedModel):
         )
         output_hidden_states = True
         output_attentions = self._output_attention
+        output_router_logits = self._output_router_logits
 
         outputs = self.orig_base_model(
             input_ids=input_ids,
@@ -51,13 +54,14 @@ class CausalLMWithUncertaintyLayerClaim(PreTrainedModel):
             labels=labels,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            output_router_logits=output_router_logits,
             return_dict=return_dict,
-            **kwargs
+            **kwargs,
         )
         logits = outputs.logits
         outputs.context_lengths = context_lengths
 
-        ue_head_input = {"input_ids": input_ids, 
+        ue_head_input = {"input_ids": input_ids,
                          "attention_mask": attention_mask,
                          "claims": claims}
 

--- a/luh/cli/train/run_train_uhead.py
+++ b/luh/cli/train/run_train_uhead.py
@@ -99,6 +99,7 @@ def load_model(config):
             ue_head=uq_head,
             ue_pos_weight=config.ue_layer.pos_weight,
             output_attention=uq_head.output_attentions,
+            output_router_logits=uq_head.output_router_logits,
         )
     elif uq_head.model_type == "token":
         model = CausalLMWithUncertaintyLayer(
@@ -106,6 +107,7 @@ def load_model(config):
             ue_head=uq_head,
             ue_pos_weight=config.ue_layer.pos_weight,
             output_attention=uq_head.output_attentions,
+            output_router_logits=uq_head.output_router_logits,
         )
 
     for name, param in model.named_parameters():

--- a/luh/feature_extractors/__init__.py
+++ b/luh/feature_extractors/__init__.py
@@ -3,3 +3,4 @@ from .basic_hidden_states import FeatureExtractorBasicHiddenStates
 from .combined import FeatureExtractorCombined
 from .lookback_lens import FeatureExtractorLookbackLens
 from .final_output_ranks import FinalOutputRanks
+from .mixtral_router import FeatureExtractorMixtralRouter

--- a/luh/feature_extractors/combined.py
+++ b/luh/feature_extractors/combined.py
@@ -32,6 +32,9 @@ class FeatureExtractorCombined(FeatureExtractorBase):
     def output_attention(self):
         return any(fe.output_attention() for fe in self._feature_extractors)
 
+    def output_router_logits(self):
+        return any(fe.output_router_logits() for fe in self._feature_extractors)
+
 
 def load_extractor(config, base_model):
     feature_extractors = []

--- a/luh/feature_extractors/feature_extractor_base.py
+++ b/luh/feature_extractors/feature_extractor_base.py
@@ -15,3 +15,6 @@ class FeatureExtractorBase(ABC):
 
     def output_attention(self):
         return False
+
+    def output_router_logits(self):
+        return False

--- a/luh/feature_extractors/mixtral_router.py
+++ b/luh/feature_extractors/mixtral_router.py
@@ -1,0 +1,93 @@
+import torch
+
+from .feature_extractor_base import FeatureExtractorBase
+
+
+class FeatureExtractorMixtralRouter(FeatureExtractorBase):
+    def __init__(self, orig_base_model, layer_nums="all", normalize=True, **kwargs):
+        self._requested_layer_nums = layer_nums
+        self._resolved_layer_nums = None
+        self._normalize = normalize
+        self._num_experts = getattr(
+            orig_base_model.config, "num_local_experts", getattr(orig_base_model.config, "num_experts", None)
+        )
+        self._total_layers = getattr(orig_base_model.config, "num_hidden_layers", None)
+        self._feature_dim_value = None
+
+        if self._total_layers is not None:
+            self._resolved_layer_nums = self._normalize_layer_ids(self._total_layers)
+            if self._num_experts is not None:
+                self._feature_dim_value = self._num_experts * len(self._resolved_layer_nums)
+
+    def _normalize_layer_ids(self, total_layers):
+        if self._requested_layer_nums == "all":
+            return list(range(total_layers))
+
+        if isinstance(self._requested_layer_nums, int):
+            requested = [self._requested_layer_nums]
+        else:
+            requested = list(self._requested_layer_nums)
+
+        normalized = []
+        for l in requested:
+            normalized.append(l if l >= 0 else total_layers + l)
+        return normalized
+
+    def _prepare_generation_logits(self, router_logits):
+        if isinstance(router_logits[0], torch.Tensor):
+            return router_logits
+
+        per_layer_logits = []
+        num_layers = len(router_logits[0])
+        for layer_idx in range(num_layers):
+            per_layer_logits.append(
+                torch.cat([step[layer_idx] for step in router_logits], dim=1)
+            )
+        return per_layer_logits
+
+    def _resolve_metadata(self, router_logits):
+        if self._resolved_layer_nums is None:
+            self._resolved_layer_nums = self._normalize_layer_ids(len(router_logits))
+        if self._num_experts is None:
+            self._num_experts = router_logits[self._resolved_layer_nums[0]].shape[-1]
+        if self._feature_dim_value is None:
+            self._feature_dim_value = self._num_experts * len(self._resolved_layer_nums)
+
+    def __call__(self, llm_inputs, llm_outputs):
+        if "router_logits" not in llm_outputs:
+            raise ValueError("Model outputs must include router_logits. Ensure output_router_logits=True during the forward call.")
+
+        router_logits = llm_outputs["router_logits"]
+        is_training = not hasattr(llm_outputs, "sequences")
+        router_logits = (
+            router_logits if is_training else self._prepare_generation_logits(router_logits)
+        )
+
+        self._resolve_metadata(router_logits)
+
+        layer_features = []
+        for layer_idx in self._resolved_layer_nums:
+            logits = router_logits[layer_idx]
+            if is_training:
+                logits = logits[:, :-1, :]
+            if self._normalize:
+                logits = torch.softmax(logits, dim=-1)
+            layer_features.append(logits)
+
+        return torch.cat(layer_features, dim=-1)
+
+    def feature_dim(self):
+        if self._feature_dim_value is None:
+            if self._num_experts is not None and self._resolved_layer_nums is not None:
+                self._feature_dim_value = self._num_experts * len(self._resolved_layer_nums)
+            else:
+                raise ValueError("Router feature dimension is undefined. Ensure the model config exposes num_hidden_layers and num_experts or run a forward pass first.")
+
+        return self._feature_dim_value
+
+    def output_router_logits(self):
+        return True
+
+
+def load_extractor(config, base_model):
+    return FeatureExtractorMixtralRouter(base_model, **config)

--- a/luh/heads/uncertainty_head_base.py
+++ b/luh/heads/uncertainty_head_base.py
@@ -47,6 +47,10 @@ class UncertaintyHeadBase(nn.Module):
     def output_attentions(self):
         return self.feature_extractor.output_attention()
 
+    @property
+    def output_router_logits(self):
+        return self.feature_extractor.output_router_logits()
+
     @classmethod
     def from_pretrained(
         cls,


### PR DESCRIPTION
## Summary
- avoid requesting router logits in inference unless the uncertainty head exposes them
- keep router logit requests tied to feature extractor needs without assuming MoE behavior

## Testing
- python -m compileall luh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69561200375c8331b5f6d785da656eac)